### PR TITLE
fix loadavg gathered from uptime to not contain the comma

### DIFF
--- a/iwm_trace.sh
+++ b/iwm_trace.sh
@@ -97,7 +97,7 @@ get_loadavg() {
  if [[ -f /proc/loadavg ]]; then
    awk '{ print $2 }' /proc/loadavg
  else
-   uptime | sed 's/\(.*\)load average\(.*\) \(.*\) \(.*\)/\3/g'
+   uptime | sed 's/\(.*\)load average\(.*\) \(.*\)[,] \(.*\)/\3/g'
  fi
 }
 


### PR DESCRIPTION
loadavg values end in comma in uptime, it needs to be stripped:

```
yunake@v02:/home/yunake$ uname
OpenBSD
yunake@v02:/home/yunake$ uptime
6:44PM  up 173 days,  3:59, 2 users, load averages: 0.15, 0.10, 0.09
```
